### PR TITLE
1 player test version

### DIFF
--- a/server_build/game/card.js
+++ b/server_build/game/card.js
@@ -1,5 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.Cards = void 0;
 exports.hasType = hasType;
 exports.getPrimaryType = getPrimaryType;
 exports.initializeDeck = initializeDeck;
@@ -11,7 +12,7 @@ function hasType(card, type) {
 function getPrimaryType(card) {
     return Array.isArray(card.type) ? card.type[0] : card.type;
 }
-const Cards = [{
+exports.Cards = [{
         title: "Baby Unicorn",
         type: "baby",
         image: "baby0",
@@ -1828,7 +1829,7 @@ const Cards = [{
     }];
 function initializeDeck() {
     let deck = [];
-    Cards.forEach(c => {
+    exports.Cards.forEach(c => {
         for (let i = 0; i < c.count; i++) {
             deck.push({
                 id: 0,

--- a/server_build/game/effect.js
+++ b/server_build/game/effect.js
@@ -1,8 +1,25 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.KNOWN_EFFECTS = void 0;
 exports.hasEffect = hasEffect;
 exports.isCardBasicDueToEffect = isCardBasicDueToEffect;
 const card_1 = require("./card");
+exports.KNOWN_EFFECTS = [
+    "save_mate_by_sacrifice",
+    "basic_unicorns_can_only_join_your_stable",
+    "can_play_two_cards",
+    "your_cards_cannot_be_neighed",
+    "your_unicorns_cannot_be_destroyed",
+    "double_dutch",
+    "my_unicorns_are_basic",
+    "you_cannot_play_upgrades",
+    "pandamonium",
+    "you_cannot_play_neigh",
+    "tiny_stable",
+    "change_of_luck",
+    "your_hand_is_visible",
+    "count_as_two",
+];
 function hasEffect(playerEffects, key) {
     return playerEffects.some(e => e.effect.key === key);
 }

--- a/server_build/game/game.js
+++ b/server_build/game/game.js
@@ -13,6 +13,8 @@ const card_1 = require("./card");
 const constants_1 = require("./constants");
 const effect_1 = require("./effect");
 const underscore_1 = __importDefault(require("underscore"));
+const registerStages_1 = require("./sandbox/registerStages");
+const sandboxOverrides_1 = require("./sandbox/sandboxOverrides");
 const state_1 = require("./state");
 var state_2 = require("./state");
 Object.defineProperty(exports, "_findInstruction", { enumerable: true, get: function () { return state_2._findInstruction; } });
@@ -22,10 +24,12 @@ Object.defineProperty(exports, "_addSceneFromDo", { enumerable: true, get: funct
 const UnstableUnicorns = {
     name: "unstable_unicorns",
     setup: (ctx, setupData) => {
+        const sandboxMode = setupData?.sandbox === true;
+        const sandboxNames = ["player", "dummy_1", "dummy_2"];
         const players = Array.from({ length: ctx.numPlayers }, (val, idx) => {
             return {
                 id: `${idx}`,
-                name: `Spieler ${idx}`,
+                name: sandboxMode ? (sandboxNames[idx] ?? `dummy_${idx}`) : `Spieler ${idx}`,
             };
         });
         const deck = (0, card_1.initializeDeck)();
@@ -49,6 +53,19 @@ const UnstableUnicorns = {
             playerEffects[pl.id] = [];
             lastHeartbeat[pl.id] = Date.now();
         });
+        let babyStarter = [];
+        if (sandboxMode) {
+            // Pre-assign one random baby unicorn per player; remaining go to nursery.
+            const babyIDs = deck.filter(c => (0, card_1.hasType)(c, "baby")).map(c => c.id);
+            const shuffledBabies = underscore_1.default.shuffle(babyIDs);
+            players.forEach((pl, idx) => {
+                const babyID = shuffledBabies[idx];
+                stable[pl.id] = [babyID];
+                babyStarter.push({ cardID: babyID, owner: pl.id });
+                ready[pl.id] = true;
+            });
+            nursery = shuffledBabies.slice(players.length);
+        }
         return {
             players,
             deck,
@@ -65,18 +82,24 @@ const UnstableUnicorns = {
             countPlayedCardsInActionPhase: 0,
             clipboard: {},
             endGame: false,
-            babyStarter: [],
+            babyStarter,
             ready,
             lastNeighResult: undefined,
             owner: setupData?.ownerPlayerID ?? "0",
             lastHeartbeat,
             deckWasReshuffled: false,
+            sandbox: sandboxMode || undefined,
+            sandboxSettings: sandboxMode ? { infiniteActions: true, skipNeigh: true } : undefined,
         };
     },
     phases: {
         pregame: {
             start: true,
             onBegin: (G, ctx) => {
+                if (G.sandbox) {
+                    ctx.events?.setPhase("main");
+                    return;
+                }
                 ctx.events?.setActivePlayers({ all: "pregame" });
             }
         },
@@ -94,7 +117,12 @@ const UnstableUnicorns = {
             G.deckWasReshuffled = false;
             // this is run whenever a new player starts its turn
             // perfect for placing players in a stage
-            if (G.drawPile.length > 0 || G.discardPile.length > 0) {
+            if (G.drawPile.length === 0 && G.discardPile.length > 0) {
+                G.drawPile = underscore_1.default.shuffle(G.discardPile);
+                G.discardPile = [];
+                G.deckWasReshuffled = true;
+            }
+            if (G.drawPile.length > 0) {
                 G.script = { scenes: [] };
                 G.countPlayedCardsInActionPhase = 0;
                 G.mustEndTurnImmediately = false;
@@ -131,11 +159,15 @@ const UnstableUnicorns = {
                 moves: { ready, selectBaby, deselectBaby, changeName, abolishGame, heartbeat, cancelAbandonedGame }
             },
             beginning: {
-                moves: { drawAndAdvance, executeDo: operations_2.executeDo, end, commit, skipExecuteDo, abolishGame }
+                moves: {
+                    drawAndAdvance, executeDo: operations_2.executeDo, end, commit, skipExecuteDo, abolishGame,
+                    ...registerStages_1.sandboxStageMoves,
+                }
             },
             action_phase: {
                 moves: {
-                    commit, executeDo: operations_2.executeDo, end, drawAndEnd, playCard, playUpgradeDowngradeCard, playNeigh, playSuperNeigh, dontPlayNeigh, skipExecuteDo, abolishGame
+                    commit, executeDo: operations_2.executeDo, end, drawAndEnd, playCard, playUpgradeDowngradeCard, playNeigh, playSuperNeigh, dontPlayNeigh, skipExecuteDo, abolishGame,
+                    ...registerStages_1.sandboxStageMoves,
                 }
             }
         }
@@ -221,11 +253,14 @@ function drawAndAdvance(G, ctx) {
     G.script = { scenes: [] };
 }
 function canPlayCard(G, ctx, protagonist, cardID) {
-    if (ctx.currentPlayer === protagonist && ctx.activePlayers[protagonist] === "action_phase" && (G.countPlayedCardsInActionPhase === 0 || (G.countPlayedCardsInActionPhase === 1 && G.playerEffects[protagonist].find(c => c.effect.key === "double_dutch")))) {
-        const card = G.deck[cardID];
-        if ((0, card_1.hasType)(card, "upgrade") && G.playerEffects[protagonist].find(s => s.effect.key === "you_cannot_play_upgrades")) {
-            return false;
-        }
+    if (ctx.currentPlayer !== protagonist || ctx.activePlayers[protagonist] !== "action_phase")
+        return false;
+    const card = G.deck[cardID];
+    if ((0, card_1.hasType)(card, "upgrade") && G.playerEffects[protagonist].find(s => s.effect.key === "you_cannot_play_upgrades"))
+        return false;
+    if ((0, sandboxOverrides_1.sandboxBypassActionLimit)(G))
+        return (0, operations_1.canEnter)(G, ctx, { playerID: protagonist, cardID });
+    if (G.countPlayedCardsInActionPhase === 0 || (G.countPlayedCardsInActionPhase === 1 && G.playerEffects[protagonist].find(c => c.effect.key === "double_dutch"))) {
         return (0, operations_1.canEnter)(G, ctx, { playerID: protagonist, cardID });
     }
     return false;
@@ -233,7 +268,7 @@ function canPlayCard(G, ctx, protagonist, cardID) {
 function playCard(G, ctx, protagonist, cardID) {
     G.countPlayedCardsInActionPhase = G.countPlayedCardsInActionPhase + 1;
     G.hand[protagonist] = underscore_1.default.without(G.hand[protagonist], cardID);
-    if (G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
+    if ((0, sandboxOverrides_1.sandboxSkipNeigh)(G) || G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
         (0, operations_1.enter)(G, ctx, { playerID: protagonist, cardID });
     }
     else {
@@ -257,7 +292,7 @@ function initialNeighVote(G, playerID, protagonist) {
 function playUpgradeDowngradeCard(G, ctx, protagonist, targetPlayer, cardID) {
     G.countPlayedCardsInActionPhase = G.countPlayedCardsInActionPhase + 1;
     G.hand[protagonist] = underscore_1.default.without(G.hand[protagonist], cardID);
-    if (G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
+    if ((0, sandboxOverrides_1.sandboxSkipNeigh)(G) || G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
         (0, operations_1.enter)(G, ctx, { playerID: targetPlayer, cardID });
     }
     else {
@@ -342,6 +377,10 @@ function dontPlayNeigh(G, ctx, protagonist, roundIndex) {
     }
 }
 function canDraw(G, ctx) {
+    if ((0, sandboxOverrides_1.sandboxBypassActionLimit)(G)) {
+        const stage = ctx.activePlayers?.[ctx.currentPlayer];
+        return stage === "action_phase" || stage === "beginning";
+    }
     if (G.mustEndTurnImmediately === true) {
         return false;
     }
@@ -362,6 +401,11 @@ function canDraw(G, ctx) {
     return false;
 }
 function drawAndEnd(G, ctx) {
+    if ((0, sandboxOverrides_1.sandboxBypassActionLimit)(G)) {
+        G.hand[ctx.currentPlayer].push(underscore_1.default.first(G.drawPile));
+        G.drawPile = underscore_1.default.rest(G.drawPile, 1);
+        return;
+    }
     G.script = { scenes: [] };
     G.hand[ctx.currentPlayer].push(underscore_1.default.first(G.drawPile));
     G.drawPile = underscore_1.default.rest(G.drawPile, 1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Switch, Route, Redirect } from "react-router-dom";
 import Client from './Client';
 import LobbyPage from './components/lobby/LobbyPage';
+import SandboxClient from './sandbox/SandboxClient';
 
 const App = () => {
   return (
@@ -9,6 +10,9 @@ const App = () => {
         <Switch>
           <Route path="/test">
             <Client debug={"test"}/>
+          </Route>
+          <Route path="/sandbox">
+            <SandboxClient />
           </Route>
           <Route path="/lobby">
             <LobbyPage />

--- a/src/Board.tsx
+++ b/src/Board.tsx
@@ -34,6 +34,9 @@ import { useMobile } from './hooks/useMobile';
 import MobileBoard from './mobile/MobileBoard';
 import { useGameSettings } from './hooks/useGameSettings';
 import { useAutoActions } from './hooks/useAutoActions';
+import SandboxPanel from './sandbox/SandboxPanel';
+import SandboxActionBanner from './sandbox/SandboxActionBanner';
+import { useSandboxControl } from './sandbox/sandboxContext';
 
 type Props = {
     G: UnstableUnicornsGame;
@@ -54,6 +57,7 @@ const DesktopBoard = (props: Props) => {
     const { G, ctx, playerID, moves } = props;
 
     const { playDrawCardSound, playEndTurnButtonSound, playHubMouseOverSound, playExecuteDoSound } = useSoundEffects(G, ctx, playerID);
+    const { sandboxAction, setSandboxAction } = useSandboxControl();
 
     const [showDeckFinder, setShowDeckFinder] = useState<SearchTarget[] | undefined>(undefined);
     const [showPlayerHand, setShowPlayerHand] = useState<PlayerID | undefined>(undefined);
@@ -126,7 +130,11 @@ const DesktopBoard = (props: Props) => {
     const [escapeMenuOpen, setEscapeMenuOpen] = useState(false);
     const [gameoverDismissed, setGameoverDismissed] = useState(false);
     const { autoEndTurn, setAutoEndTurn, autoDontNeigh, setAutoDontNeigh } = useGameSettings();
-    useAutoActions(G, ctx, playerID, moves, { autoEndTurn, autoDontNeigh }, boardStates);
+    const isSandboxDummy = G.sandbox === true && playerID !== G.owner;
+    useAutoActions(G, ctx, playerID, moves, {
+        autoEndTurn: isSandboxDummy ? false : autoEndTurn,
+        autoDontNeigh: isSandboxDummy ? false : autoDontNeigh,
+    }, boardStates);
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
@@ -230,6 +238,18 @@ const DesktopBoard = (props: Props) => {
                         highlightMode={stableHighlightMode}
                         onHandClick={playerID => setShowPlayerHand(playerID)}
                         onStableCardClick={cardID => {
+                            if (sandboxAction) {
+                                if (sandboxAction.type === 'bounce') {
+                                    moves.sandboxBounceCard(cardID);
+                                    setSandboxAction(null);
+                                } else if (sandboxAction.type === 'destroy') {
+                                    moves.sandboxDestroyCard(cardID);
+                                    setSandboxAction(null);
+                                } else if (sandboxAction.type === 'steal' && sandboxAction.step === 'pick_card') {
+                                    setSandboxAction({ type: 'steal', step: 'pick_target', cardID });
+                                }
+                                return;
+                            }
                             if (cardInteraction?.key === "click_on_other_stable_card" || cardInteraction?.key === "card_to_card") {
                                 console.log("Detected click for cardInteraction with key <click_on_other_stable_card | card_to_card>");
                                 // is clicked card a valid target?
@@ -338,6 +358,12 @@ const DesktopBoard = (props: Props) => {
                 </Bottom>
             </Wrapper>
             </AnimateSharedLayout>
+            {G.sandbox && (
+                <>
+                    <SandboxActionBanner />
+                    <SandboxPanel G={G} ctx={ctx} moves={moves as any} playerID={playerID} />
+                </>
+            )}
         </>
     );
 }

--- a/src/BoardStateManager.tsx
+++ b/src/BoardStateManager.tsx
@@ -1,6 +1,7 @@
 import type { UnstableUnicornsGame, Ctx, Instruction, Scene } from "./game/state";
 import { _findOpenScenesWithProtagonist, _findInProgressScenesWithProtagonist } from "./game/state";
 import { canDraw } from "./game/game";
+import { sandboxBypassActionLimit } from "./game/sandbox/sandboxOverrides";
 import type { PlayerID } from "./game/player";
 import _ from 'underscore';
 import { canBringToStableTargets, findAddFromDiscardPileToHand, findBackKickTargets, findBringToStableTargets, findDestroyTargets, findDiscardTargets, findMakeSomeoneDiscardTarget, findMoveTargets, findMoveTargets2, findPullRandomTargets, findReturnToHandTargets, findReviveTarget, findSacrificeTargets, findSearchTargets, findStealTargets, findSwapHandsTargets, findUnicornSwap1Targets, findUnicornSwap2Targets, canDiscard, canSatisfyDo } from "./game/operations";
@@ -71,6 +72,23 @@ export function getBoardState(G: UnstableUnicornsGame, ctx: Ctx, playerID: Playe
     }
 
     if (playerID === ctx.currentPlayer) {
+        // Sandbox infinite-actions: always offer draw + play + endTurn during action_phase,
+        // regardless of countPlayedCardsInActionPhase. Mirrors the structure of the bottom
+        // action_phase block but without the count gating.
+        if (sandboxBypassActionLimit(G) && G.neighDiscussion === undefined && ctx.activePlayers![playerID] === "action_phase") {
+            if (inProgressScenes.length > 0) {
+                return [...getExecutionDoState(G, ctx, playerID, inProgressScenes)];
+            }
+            const otherInProgress = G.players.filter(pl => pl.id !== playerID).map(pl => _findInProgressScenesWithProtagonist(G, pl.id)).find(ar => ar.length > 0);
+            if (otherInProgress) {
+                return [{ type: "wait_for_other_players" }];
+            }
+            if (openScenes.length > 0) {
+                return [...getExecutionDoState(G, ctx, playerID, openScenes), { type: "endTurn" }, { type: "playCard" }, { type: "drawCard" }];
+            }
+            return [{ type: "drawCard" }, { type: "playCard" }, { type: "endTurn" }];
+        }
+
         if (G.countPlayedCardsInActionPhase === 0 && G.neighDiscussion === undefined && ctx.activePlayers![playerID] === "action_phase") {
             // action phase and no card has been played or drawn
             // player may draw a card or play a card

--- a/src/components/StableSection.tsx
+++ b/src/components/StableSection.tsx
@@ -11,6 +11,7 @@ import type { AddFromDiscardPileToHandTarget, BringToStableTarget, DiscardTarget
 import { CardID, hasType } from '../game/card';
 import type { Moves } from '../game/types';
 import { BoardState } from '../BoardStateManager';
+import { useSandboxControl } from '../sandbox/sandboxContext';
 
 type Props = {
     G: UnstableUnicornsGame;
@@ -57,6 +58,8 @@ const StableSection = ({
     playHubMouseOverSound,
     playExecuteDoSound,
 }: Props) => {
+    const { sandboxAction, setSandboxAction } = useSandboxControl();
+
     // renderHand logic inlined
     let glowingCards: CardID[] = [];
 
@@ -80,6 +83,15 @@ const StableSection = ({
     }
 
     const onHandCardClick = (evt: React.MouseEvent, cardID: CardID) => {
+        if (sandboxAction) {
+            if (sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_card') {
+                setSandboxAction({ type: 'move_to_stable', step: 'pick_stable', cardID });
+            } else if (sandboxAction.type === 'force_discard') {
+                moves.sandboxForceDiscardCard(sandboxAction.playerID, cardID);
+                setSandboxAction(null);
+            }
+            return;
+        }
         if (boardStates.find(s => s.type === "playCard")) {
             const cardsOnHandThatCanBePlayed = G.hand[playerID].map(c => [canPlayCard(G, ctx, playerID, c), c]).filter(s => s[0]).map(s => s[1]) as CardID[];
             if (cardsOnHandThatCanBePlayed.includes(cardID)) {
@@ -133,6 +145,18 @@ const StableSection = ({
                 glowing={glowingCardIDs}
                 highlightMode={stableHighlightMode}
                 onStableItemClick={(evt, cardID) => {
+                    if (sandboxAction) {
+                        if (sandboxAction.type === 'bounce') {
+                            moves.sandboxBounceCard(cardID);
+                            setSandboxAction(null);
+                        } else if (sandboxAction.type === 'destroy') {
+                            moves.sandboxDestroyCard(cardID);
+                            setSandboxAction(null);
+                        } else if (sandboxAction.type === 'steal' && sandboxAction.step === 'pick_card') {
+                            setSandboxAction({ type: 'steal', step: 'pick_target', cardID });
+                        }
+                        return;
+                    }
                     // initiate card to card interaction for destroy and steal actions
                     if (cardInteraction === undefined) {
                         // check if it is a destroy or steal action

--- a/src/components/lobby/CreateGameCard.tsx
+++ b/src/components/lobby/CreateGameCard.tsx
@@ -36,6 +36,7 @@ const CreateGameCard = ({ matchName, setMatchName, numPlayers, setNumPlayers, on
                         value={numPlayers}
                         onChange={(e) => setNumPlayers(parseInt(e.target.value))}
                     >
+                        <option value={1}>1 Player (Sandbox)</option>
                         {[2, 3, 4, 5, 6, 7, 8].map((n) => (
                             <option key={n} value={n}>{n} Players</option>
                         ))}

--- a/src/components/lobby/LobbyPage.tsx
+++ b/src/components/lobby/LobbyPage.tsx
@@ -30,6 +30,11 @@ const LobbyPage = () => {
     }, []);
 
     const createMatch = async () => {
+        if (numPlayers === 1) {
+            const w = window.open('/sandbox', '_blank');
+            if (w) w.opener = null;
+            return;
+        }
         try {
             const response = await fetch(`${API_URL}/games/unstable_unicorns/create`, {
                 method: 'POST',
@@ -92,20 +97,12 @@ const LobbyPage = () => {
         }
     };
 
-    const openSandbox = () => {
-        const w = window.open('/sandbox', '_blank');
-        if (w) w.opener = null;
-    };
-
     return (
         <PageWrapper>
             <ContentColumn>
                 <LogoWrapper>
                     <Logo>Unstable Unicorns</Logo>
                 </LogoWrapper>
-                <SandboxRow>
-                    <SandboxButton onClick={openSandbox}>Open Sandbox</SandboxButton>
-                </SandboxRow>
                 <CreateGameCard
                     matchName={matchName}
                     setMatchName={setMatchName}
@@ -144,30 +141,6 @@ const ContentColumn = styled.div`
 const LogoWrapper = styled.div`
     text-align: center;
     margin-bottom: 32px;
-`;
-
-const SandboxRow = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    margin-bottom: 12px;
-`;
-
-const SandboxButton = styled.button`
-    background: transparent;
-    color: #9d7fe0;
-    border: 1px solid #9d7fe0;
-    border-radius: 8px;
-    padding: 8px 16px;
-    font-size: 13px;
-    font-family: 'Nunito', sans-serif;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.15s, color 0.15s;
-
-    &:hover {
-        background: #9d7fe0;
-        color: #fff;
-    }
 `;
 
 const Logo = styled.h1`

--- a/src/components/lobby/LobbyPage.tsx
+++ b/src/components/lobby/LobbyPage.tsx
@@ -92,12 +92,20 @@ const LobbyPage = () => {
         }
     };
 
+    const openSandbox = () => {
+        const w = window.open('/sandbox', '_blank');
+        if (w) w.opener = null;
+    };
+
     return (
         <PageWrapper>
             <ContentColumn>
                 <LogoWrapper>
                     <Logo>Unstable Unicorns</Logo>
                 </LogoWrapper>
+                <SandboxRow>
+                    <SandboxButton onClick={openSandbox}>Open Sandbox</SandboxButton>
+                </SandboxRow>
                 <CreateGameCard
                     matchName={matchName}
                     setMatchName={setMatchName}
@@ -136,6 +144,30 @@ const ContentColumn = styled.div`
 const LogoWrapper = styled.div`
     text-align: center;
     margin-bottom: 32px;
+`;
+
+const SandboxRow = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+`;
+
+const SandboxButton = styled.button`
+    background: transparent;
+    color: #9d7fe0;
+    border: 1px solid #9d7fe0;
+    border-radius: 8px;
+    padding: 8px 16px;
+    font-size: 13px;
+    font-family: 'Nunito', sans-serif;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+
+    &:hover {
+        background: #9d7fe0;
+        color: #fff;
+    }
 `;
 
 const Logo = styled.h1`

--- a/src/game/card.ts
+++ b/src/game/card.ts
@@ -13,7 +13,7 @@ export interface Card {
     description: {en: string, de: string};
 }
 
-interface CardDefinition {
+export interface CardDefinition {
     title: string;
     image: string;
     count: number;
@@ -112,7 +112,7 @@ type Passive = ("count_as_two" | "cannot_be_destroyed_by_magic" | "basic_unicorn
 
 
 
-const Cards: CardDefinition[] = [{
+export const Cards: CardDefinition[] = [{
     title: "Baby Unicorn",
     type: "baby",
     image: "baby0",

--- a/src/game/effect.ts
+++ b/src/game/effect.ts
@@ -5,6 +5,23 @@ export type Effect = {
     key: "save_mate_by_sacrifice" | "basic_unicorns_can_only_join_your_stable" | "can_play_two_cards" | "your_cards_cannot_be_neighed" | "your_unicorns_cannot_be_destroyed" | "double_dutch" | "my_unicorns_are_basic" | "you_cannot_play_upgrades" | "pandamonium" | "you_cannot_play_neigh" | "tiny_stable" | "change_of_luck" | "your_hand_is_visible" | "count_as_two"
 };
 
+export const KNOWN_EFFECTS: Effect["key"][] = [
+    "save_mate_by_sacrifice",
+    "basic_unicorns_can_only_join_your_stable",
+    "can_play_two_cards",
+    "your_cards_cannot_be_neighed",
+    "your_unicorns_cannot_be_destroyed",
+    "double_dutch",
+    "my_unicorns_are_basic",
+    "you_cannot_play_upgrades",
+    "pandamonium",
+    "you_cannot_play_neigh",
+    "tiny_stable",
+    "change_of_luck",
+    "your_hand_is_visible",
+    "count_as_two",
+];
+
 type PlayerEffectEntry = { effect: Effect };
 
 export function hasEffect(playerEffects: PlayerEffectEntry[], key: Effect["key"]): boolean {

--- a/src/game/game.ts
+++ b/src/game/game.ts
@@ -9,6 +9,8 @@ import { CONSTANTS } from './constants';
 import { Effect, isCardBasicDueToEffect } from './effect';
 import _ from 'underscore';
 import type { SetupData } from './types';
+import { sandboxStageMoves } from './sandbox/registerStages';
+import { sandboxBypassActionLimit, sandboxSkipNeigh } from './sandbox/sandboxOverrides';
 import {
     UnstableUnicornsGame,
     Scene,
@@ -28,10 +30,13 @@ export { _findInstruction, _findOpenScenesWithProtagonist, _findInProgressScenes
 const UnstableUnicorns = {
     name: "unstable_unicorns",
     setup: (ctx: Ctx, setupData: SetupData): UnstableUnicornsGame => {
+        const sandboxMode = setupData?.sandbox === true;
+
+        const sandboxNames = ["player", "dummy_1", "dummy_2"];
         const players: Player[] = Array.from({ length: ctx.numPlayers }, (val, idx) => {
             return {
                 id: `${idx}`,
-                name: `Spieler ${idx}`,
+                name: sandboxMode ? (sandboxNames[idx] ?? `dummy_${idx}`) : `Spieler ${idx}`,
             };
         });
 
@@ -58,6 +63,21 @@ const UnstableUnicorns = {
             lastHeartbeat[pl.id] = Date.now();
         });
 
+        let babyStarter: { cardID: CardID, owner: PlayerID }[] = [];
+
+        if (sandboxMode) {
+            // Pre-assign one random baby unicorn per player; remaining go to nursery.
+            const babyIDs = deck.filter(c => hasType(c, "baby")).map(c => c.id);
+            const shuffledBabies = _.shuffle(babyIDs);
+            players.forEach((pl, idx) => {
+                const babyID = shuffledBabies[idx];
+                stable[pl.id] = [babyID];
+                babyStarter.push({ cardID: babyID, owner: pl.id });
+                ready[pl.id] = true;
+            });
+            nursery = shuffledBabies.slice(players.length);
+        }
+
         return {
             players,
             deck,
@@ -74,18 +94,24 @@ const UnstableUnicorns = {
             countPlayedCardsInActionPhase: 0,
             clipboard: {},
             endGame: false,
-            babyStarter: [],
+            babyStarter,
             ready,
             lastNeighResult: undefined,
             owner: setupData?.ownerPlayerID ?? "0",
             lastHeartbeat,
             deckWasReshuffled: false,
+            sandbox: sandboxMode || undefined,
+            sandboxSettings: sandboxMode ? { infiniteActions: true, skipNeigh: true } : undefined,
         };
     },
     phases: {
         pregame: {
             start: true,
             onBegin: (G: UnstableUnicornsGame, ctx: Ctx) => {
+                if (G.sandbox) {
+                    ctx.events?.setPhase!("main");
+                    return;
+                }
                 ctx.events?.setActivePlayers!({all: "pregame"})
             }
         },
@@ -153,11 +179,15 @@ const UnstableUnicorns = {
                 moves: { ready, selectBaby, deselectBaby, changeName, abolishGame, heartbeat, cancelAbandonedGame }
             },
             beginning: {
-                moves: { drawAndAdvance, executeDo, end, commit, skipExecuteDo, abolishGame }
+                moves: {
+                    drawAndAdvance, executeDo, end, commit, skipExecuteDo, abolishGame,
+                    ...sandboxStageMoves,
+                }
             },
             action_phase: {
                 moves: {
-                    commit, executeDo, end, drawAndEnd, playCard, playUpgradeDowngradeCard, playNeigh, playSuperNeigh, dontPlayNeigh, skipExecuteDo, abolishGame
+                    commit, executeDo, end, drawAndEnd, playCard, playUpgradeDowngradeCard, playNeigh, playSuperNeigh, dontPlayNeigh, skipExecuteDo, abolishGame,
+                    ...sandboxStageMoves,
                 }
             }
         }
@@ -256,14 +286,13 @@ function drawAndAdvance(G: UnstableUnicornsGame, ctx: Ctx) {
 }
 
 export function canPlayCard(G: UnstableUnicornsGame, ctx: Ctx, protagonist: PlayerID, cardID: CardID) {
-    if (ctx.currentPlayer === protagonist && ctx.activePlayers![protagonist] === "action_phase" && (G.countPlayedCardsInActionPhase === 0 || (G.countPlayedCardsInActionPhase === 1 && G.playerEffects[protagonist].find(c => c.effect.key === "double_dutch")))) {
-        const card = G.deck[cardID];
-        if (hasType(card, "upgrade") && G.playerEffects[protagonist].find(s => s.effect.key === "you_cannot_play_upgrades")) {
-            return false;
-        }
+    if (ctx.currentPlayer !== protagonist || ctx.activePlayers![protagonist] !== "action_phase") return false;
+    const card = G.deck[cardID];
+    if (hasType(card, "upgrade") && G.playerEffects[protagonist].find(s => s.effect.key === "you_cannot_play_upgrades")) return false;
+    if (sandboxBypassActionLimit(G)) return canEnter(G, ctx, { playerID: protagonist, cardID });
+    if (G.countPlayedCardsInActionPhase === 0 || (G.countPlayedCardsInActionPhase === 1 && G.playerEffects[protagonist].find(c => c.effect.key === "double_dutch"))) {
         return canEnter(G, ctx, { playerID: protagonist, cardID });
     }
-
     return false;
 }
 
@@ -271,7 +300,7 @@ function playCard(G: UnstableUnicornsGame, ctx: Ctx, protagonist: PlayerID, card
     G.countPlayedCardsInActionPhase = G.countPlayedCardsInActionPhase + 1;
     G.hand[protagonist] = _.without(G.hand[protagonist], cardID);
 
-    if (G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
+    if (sandboxSkipNeigh(G) || G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
         enter(G, ctx, { playerID: protagonist, cardID });
     } else {
         // resolve neigh
@@ -295,7 +324,7 @@ function playUpgradeDowngradeCard(G: UnstableUnicornsGame, ctx: Ctx, protagonist
     G.countPlayedCardsInActionPhase = G.countPlayedCardsInActionPhase + 1;
     G.hand[protagonist] = _.without(G.hand[protagonist], cardID);
 
-    if (G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
+    if (sandboxSkipNeigh(G) || G.playerEffects[protagonist].findIndex(f => f.effect.key === "your_cards_cannot_be_neighed") > -1) {
         enter(G, ctx, { playerID: targetPlayer, cardID });
     } else {
         // resolve neigh
@@ -383,6 +412,11 @@ function dontPlayNeigh(G: UnstableUnicornsGame, ctx: Ctx, protagonist: PlayerID,
 }
 
 export function canDraw(G: UnstableUnicornsGame, ctx: Ctx) {
+    if (sandboxBypassActionLimit(G)) {
+        const stage = ctx.activePlayers?.[ctx.currentPlayer];
+        return stage === "action_phase" || stage === "beginning";
+    }
+
     if (G.mustEndTurnImmediately === true) {
         return false;
     }
@@ -409,6 +443,11 @@ export function canDraw(G: UnstableUnicornsGame, ctx: Ctx) {
 }
 
 function drawAndEnd(G: UnstableUnicornsGame, ctx: Ctx) {
+    if (sandboxBypassActionLimit(G)) {
+        G.hand[ctx.currentPlayer].push(_.first(G.drawPile)!);
+        G.drawPile = _.rest(G.drawPile, 1);
+        return;
+    }
     G.script = { scenes: [] };
     G.hand[ctx.currentPlayer].push(_.first(G.drawPile)!);
     G.drawPile = _.rest(G.drawPile, 1);

--- a/src/game/sandbox/registerStages.ts
+++ b/src/game/sandbox/registerStages.ts
@@ -1,0 +1,19 @@
+import {
+    sandboxAddToHand, sandboxAddToStable, sandboxAddToDiscard, sandboxAddToDeckTop,
+    sandboxAddToNursery, sandboxDraw, sandboxDiscardRandom, sandboxEmptyHand,
+    sandboxForceEndTurn, sandboxReshuffleDiscard, sandboxAddEffect, sandboxRemoveEffect,
+    sandboxClearAllEffects, sandboxClearSceneQueue, sandboxCancelNeigh, sandboxLoadState,
+    sandboxSetSetting, sandboxResolveNeighAsPlayed,
+    sandboxBounceCard, sandboxDestroyCard, sandboxStealCard, sandboxHandToStable,
+    sandboxForceDiscardCard,
+} from './sandboxMoves';
+
+export const sandboxStageMoves = {
+    sandboxAddToHand, sandboxAddToStable, sandboxAddToDiscard, sandboxAddToDeckTop,
+    sandboxAddToNursery, sandboxDraw, sandboxDiscardRandom, sandboxEmptyHand,
+    sandboxForceEndTurn, sandboxReshuffleDiscard, sandboxAddEffect, sandboxRemoveEffect,
+    sandboxClearAllEffects, sandboxClearSceneQueue, sandboxCancelNeigh, sandboxLoadState,
+    sandboxSetSetting, sandboxResolveNeighAsPlayed,
+    sandboxBounceCard, sandboxDestroyCard, sandboxStealCard, sandboxHandToStable,
+    sandboxForceDiscardCard,
+};

--- a/src/game/sandbox/sandboxMoves.ts
+++ b/src/game/sandbox/sandboxMoves.ts
@@ -1,0 +1,258 @@
+import { INVALID_MOVE } from 'boardgame.io/core';
+import type { UnstableUnicornsGame, Ctx } from '../state';
+import type { CardID } from '../card';
+import { Cards, hasType } from '../card';
+import { draw, enter } from '../operations';
+import type { Effect } from '../effect';
+import type { PlayerID } from '../player';
+import _ from 'underscore';
+
+function guard(G: UnstableUnicornsGame) {
+    if (!G.sandbox) return INVALID_MOVE as any;
+    return null;
+}
+
+function spawnCard(G: UnstableUnicornsGame, defIndex: number): CardID {
+    const def = Cards[defIndex];
+    const newID = G.deck.length;
+    G.deck = [...G.deck, { ...def, id: newID }];
+    return newID;
+}
+
+export function sandboxAddToHand(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, defIndex: number) {
+    const err = guard(G); if (err) return err;
+    const cardID = spawnCard(G, defIndex);
+    G.hand[playerID] = [...G.hand[playerID], cardID];
+}
+
+export function sandboxAddToStable(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, defIndex: number, withEnter: boolean) {
+    const err = guard(G); if (err) return err;
+    const cardID = spawnCard(G, defIndex);
+    if (withEnter) {
+        enter(G, ctx, { playerID, cardID });
+    } else {
+        const card = G.deck[cardID];
+        if (hasType(card, 'upgrade') || hasType(card, 'downgrade')) {
+            G.upgradeDowngradeStable[playerID] = [...G.upgradeDowngradeStable[playerID], cardID];
+        } else if (hasType(card, 'magic')) {
+            G.temporaryStable[playerID] = [...G.temporaryStable[playerID], cardID];
+        } else {
+            G.stable[playerID] = [...G.stable[playerID], cardID];
+        }
+    }
+}
+
+export function sandboxAddToDiscard(G: UnstableUnicornsGame, ctx: Ctx, defIndex: number) {
+    const err = guard(G); if (err) return err;
+    const cardID = spawnCard(G, defIndex);
+    G.discardPile = [...G.discardPile, cardID];
+}
+
+export function sandboxAddToDeckTop(G: UnstableUnicornsGame, ctx: Ctx, defIndex: number) {
+    const err = guard(G); if (err) return err;
+    const cardID = spawnCard(G, defIndex);
+    G.drawPile = [cardID, ...G.drawPile];
+}
+
+export function sandboxAddToNursery(G: UnstableUnicornsGame, ctx: Ctx, defIndex: number) {
+    const err = guard(G); if (err) return err;
+    const cardID = spawnCard(G, defIndex);
+    G.nursery = [...G.nursery, cardID];
+}
+
+export function sandboxDraw(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, count: number) {
+    const err = guard(G); if (err) return err;
+    draw(G, ctx, { protagonist: playerID, count });
+}
+
+export function sandboxDiscardRandom(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID) {
+    const err = guard(G); if (err) return err;
+    if (G.hand[playerID].length === 0) return;
+    const idx = Math.floor(Math.random() * G.hand[playerID].length);
+    const cardID = G.hand[playerID][idx];
+    G.hand[playerID] = G.hand[playerID].filter((_, i) => i !== idx);
+    G.discardPile = [...G.discardPile, cardID];
+}
+
+export function sandboxEmptyHand(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID) {
+    const err = guard(G); if (err) return err;
+    G.discardPile = [...G.discardPile, ...G.hand[playerID]];
+    G.hand[playerID] = [];
+}
+
+export function sandboxForceEndTurn(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    ctx.events?.endTurn!();
+}
+
+export function sandboxReshuffleDiscard(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    G.drawPile = [...G.drawPile, ..._.shuffle(G.discardPile)];
+    G.discardPile = [];
+}
+
+// ─── Effects ──────────────────────────────────────────────────────────────────
+
+export function sandboxAddEffect(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, effectKey: Effect["key"]) {
+    const err = guard(G); if (err) return err;
+    G.playerEffects[playerID] = [...G.playerEffects[playerID], { effect: { key: effectKey } }];
+}
+
+export function sandboxRemoveEffect(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, index: number) {
+    const err = guard(G); if (err) return err;
+    G.playerEffects[playerID] = G.playerEffects[playerID].filter((_, i) => i !== index);
+}
+
+export function sandboxClearAllEffects(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    Object.keys(G.playerEffects).forEach(pid => { G.playerEffects[pid] = []; });
+}
+
+// ─── Flow ─────────────────────────────────────────────────────────────────────
+
+export function sandboxClearSceneQueue(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    G.script = { scenes: [] };
+}
+
+export function sandboxCancelNeigh(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    G.neighDiscussion = undefined;
+}
+
+// ─── Settings ─────────────────────────────────────────────────────────────────
+
+export type SandboxSettingKey = keyof NonNullable<UnstableUnicornsGame["sandboxSettings"]>;
+
+export function sandboxSetSetting(G: UnstableUnicornsGame, ctx: Ctx, key: SandboxSettingKey, value: boolean) {
+    const err = guard(G); if (err) return err;
+    if (!G.sandboxSettings) return INVALID_MOVE as any;
+    G.sandboxSettings[key] = value;
+}
+
+// ─── Resolve Neigh as played (fallback for skipNeigh watcher) ─────────────────
+
+export function sandboxResolveNeighAsPlayed(G: UnstableUnicornsGame, ctx: Ctx) {
+    const err = guard(G); if (err) return err;
+    if (!G.neighDiscussion) return;
+    const { target, cardID } = G.neighDiscussion;
+    G.neighDiscussion = undefined;
+    enter(G, ctx, { playerID: target, cardID });
+}
+
+// ─── Interactive quick actions ────────────────────────────────────────────────
+
+export function sandboxBounceCard(G: UnstableUnicornsGame, ctx: Ctx, cardID: CardID) {
+    const err = guard(G); if (err) return err;
+    const owner = findOwnerOfCard(G, cardID);
+    if (!owner) return;
+    const card = G.deck[cardID];
+    G.stable[owner] = _.without(G.stable[owner], cardID);
+    G.upgradeDowngradeStable[owner] = _.without(G.upgradeDowngradeStable[owner], cardID);
+    G.temporaryStable[owner] = _.without(G.temporaryStable[owner], cardID);
+    if (hasType(card, "baby")) {
+        G.nursery = [...G.nursery, cardID];
+    } else {
+        G.hand[owner] = [...G.hand[owner], cardID];
+    }
+}
+
+export function sandboxDestroyCard(G: UnstableUnicornsGame, ctx: Ctx, cardID: CardID) {
+    const err = guard(G); if (err) return err;
+    const owner = findOwnerOfCard(G, cardID);
+    if (!owner) return;
+    const card = G.deck[cardID];
+    G.stable[owner] = _.without(G.stable[owner], cardID);
+    G.upgradeDowngradeStable[owner] = _.without(G.upgradeDowngradeStable[owner], cardID);
+    G.temporaryStable[owner] = _.without(G.temporaryStable[owner], cardID);
+    if (hasType(card, "baby")) {
+        G.nursery = [...G.nursery, cardID];
+    } else {
+        G.discardPile = [...G.discardPile, cardID];
+    }
+}
+
+export function sandboxStealCard(G: UnstableUnicornsGame, ctx: Ctx, cardID: CardID, toPlayerID: PlayerID) {
+    const err = guard(G); if (err) return err;
+    const owner = findOwnerOfCard(G, cardID);
+    if (!owner) return;
+    const card = G.deck[cardID];
+    G.stable[owner] = _.without(G.stable[owner], cardID);
+    G.upgradeDowngradeStable[owner] = _.without(G.upgradeDowngradeStable[owner], cardID);
+    G.temporaryStable[owner] = _.without(G.temporaryStable[owner], cardID);
+    if (hasType(card, 'upgrade') || hasType(card, 'downgrade')) {
+        G.upgradeDowngradeStable[toPlayerID] = [...G.upgradeDowngradeStable[toPlayerID], cardID];
+    } else {
+        G.stable[toPlayerID] = [...G.stable[toPlayerID], cardID];
+    }
+}
+
+export function sandboxHandToStable(G: UnstableUnicornsGame, ctx: Ctx, cardID: CardID, toPlayerID: PlayerID) {
+    const err = guard(G); if (err) return err;
+    let fromPlayer: PlayerID | null = null;
+    G.players.forEach(pl => {
+        if (G.hand[pl.id].includes(cardID)) fromPlayer = pl.id;
+    });
+    if (!fromPlayer) return;
+    G.hand[fromPlayer] = _.without(G.hand[fromPlayer], cardID);
+    const card = G.deck[cardID];
+    if (hasType(card, 'upgrade') || hasType(card, 'downgrade')) {
+        G.upgradeDowngradeStable[toPlayerID] = [...G.upgradeDowngradeStable[toPlayerID], cardID];
+    } else if (hasType(card, 'magic')) {
+        G.temporaryStable[toPlayerID] = [...G.temporaryStable[toPlayerID], cardID];
+    } else {
+        G.stable[toPlayerID] = [...G.stable[toPlayerID], cardID];
+    }
+}
+
+export function sandboxForceDiscardCard(G: UnstableUnicornsGame, ctx: Ctx, playerID: PlayerID, cardID: CardID) {
+    const err = guard(G); if (err) return err;
+    if (!G.hand[playerID].includes(cardID)) return;
+    G.hand[playerID] = _.without(G.hand[playerID], cardID);
+    G.discardPile = [...G.discardPile, cardID];
+}
+
+function findOwnerOfCard(G: UnstableUnicornsGame, cardID: CardID): PlayerID | null {
+    for (const pl of G.players) {
+        if (G.stable[pl.id].includes(cardID) ||
+            G.upgradeDowngradeStable[pl.id].includes(cardID) ||
+            G.temporaryStable[pl.id].includes(cardID)) {
+            return pl.id;
+        }
+    }
+    return null;
+}
+
+// ─── State Save/Load ──────────────────────────────────────────────────────────
+
+type SandboxSnapshot = Pick<UnstableUnicornsGame,
+    "hand" | "stable" | "temporaryStable" | "upgradeDowngradeStable" |
+    "drawPile" | "discardPile" | "nursery" | "playerEffects" | "deck"
+>;
+
+export function sandboxLoadState(G: UnstableUnicornsGame, ctx: Ctx, snapshot: SandboxSnapshot) {
+    const err = guard(G); if (err) return err;
+    G.hand = snapshot.hand;
+    G.stable = snapshot.stable;
+    G.temporaryStable = snapshot.temporaryStable;
+    G.upgradeDowngradeStable = snapshot.upgradeDowngradeStable;
+    G.drawPile = snapshot.drawPile;
+    G.discardPile = snapshot.discardPile;
+    G.nursery = snapshot.nursery;
+    G.playerEffects = snapshot.playerEffects;
+    G.deck = snapshot.deck;
+}
+
+export function serializeSandboxSnapshot(G: UnstableUnicornsGame): SandboxSnapshot {
+    return {
+        hand: G.hand,
+        stable: G.stable,
+        temporaryStable: G.temporaryStable,
+        upgradeDowngradeStable: G.upgradeDowngradeStable,
+        drawPile: G.drawPile,
+        discardPile: G.discardPile,
+        nursery: G.nursery,
+        playerEffects: G.playerEffects,
+        deck: G.deck,
+    };
+}

--- a/src/game/sandbox/sandboxOverrides.ts
+++ b/src/game/sandbox/sandboxOverrides.ts
@@ -1,0 +1,9 @@
+import type { UnstableUnicornsGame } from '../state';
+
+export function sandboxBypassActionLimit(G: UnstableUnicornsGame): boolean {
+    return G.sandbox === true && G.sandboxSettings?.infiniteActions === true;
+}
+
+export function sandboxSkipNeigh(G: UnstableUnicornsGame): boolean {
+    return G.sandbox === true && G.sandboxSettings?.skipNeigh === true;
+}

--- a/src/game/state.ts
+++ b/src/game/state.ts
@@ -46,6 +46,11 @@ export interface UnstableUnicornsGame extends Game {
     owner: PlayerID;
     lastHeartbeat: { [key: string]: number };
     deckWasReshuffled: boolean;
+    sandbox?: boolean;
+    sandboxSettings?: {
+        infiniteActions: boolean;
+        skipNeigh: boolean;
+    };
 }
 
 // ─── Script types ─────────────────────────────────────────────────────────────

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -5,6 +5,7 @@
 
 import type { CardID } from './card';
 import type { PlayerID } from './player';
+import type { Effect } from './effect';
 
 // ─── Clipboard ────────────────────────────────────────────────────────────────
 // Temporary multi-step operation state stored on G.clipboard.
@@ -30,6 +31,7 @@ export type Clipboard = {
 export type SetupData = {
     matchName?: string;
     ownerPlayerID?: PlayerID;
+    sandbox?: boolean;
 } | undefined;
 
 // ─── BoardStateInfo ───────────────────────────────────────────────────────────
@@ -81,4 +83,28 @@ export type Moves = {
     abolishGame: (protagonist: PlayerID) => void;
     heartbeat: (protagonist: PlayerID) => void;
     cancelAbandonedGame: () => void;
+    // sandbox cheat moves (only active when G.sandbox === true)
+    sandboxAddToHand: (playerID: PlayerID, defIndex: number) => void;
+    sandboxAddToStable: (playerID: PlayerID, defIndex: number, withEnter: boolean) => void;
+    sandboxAddToDiscard: (defIndex: number) => void;
+    sandboxAddToDeckTop: (defIndex: number) => void;
+    sandboxAddToNursery: (defIndex: number) => void;
+    sandboxDraw: (playerID: PlayerID, count: number) => void;
+    sandboxDiscardRandom: (playerID: PlayerID) => void;
+    sandboxEmptyHand: (playerID: PlayerID) => void;
+    sandboxForceEndTurn: () => void;
+    sandboxReshuffleDiscard: () => void;
+    sandboxAddEffect: (playerID: PlayerID, effectKey: Effect["key"]) => void;
+    sandboxRemoveEffect: (playerID: PlayerID, index: number) => void;
+    sandboxClearAllEffects: () => void;
+    sandboxClearSceneQueue: () => void;
+    sandboxCancelNeigh: () => void;
+    sandboxLoadState: (snapshot: any) => void;
+    sandboxSetSetting: (key: "infiniteActions" | "skipNeigh", value: boolean) => void;
+    sandboxResolveNeighAsPlayed: () => void;
+    sandboxBounceCard: (cardID: CardID) => void;
+    sandboxDestroyCard: (cardID: CardID) => void;
+    sandboxStealCard: (cardID: CardID, toPlayerID: PlayerID) => void;
+    sandboxHandToStable: (cardID: CardID, toPlayerID: PlayerID) => void;
+    sandboxForceDiscardCard: (playerID: PlayerID, cardID: CardID) => void;
 };

--- a/src/mobile/MobileBoard.tsx
+++ b/src/mobile/MobileBoard.tsx
@@ -24,6 +24,9 @@ import EscapeMenu from '../components/EscapeMenu';
 import { useSoundEffects } from '../hooks/useSoundEffects';
 import { useGameSettings } from '../hooks/useGameSettings';
 import { useAutoActions } from '../hooks/useAutoActions';
+import { useSandboxControl } from '../sandbox/sandboxContext';
+import SandboxPanel from '../sandbox/SandboxPanel';
+import SandboxActionBanner from '../sandbox/SandboxActionBanner';
 
 import CharacterSelectionPage from '../components/pregame/CharacterSelectionPage';
 import LandscapeGuard from './LandscapeGuard';
@@ -66,6 +69,7 @@ const MobileBoard = ({ G, ctx, playerID, moves }: Props) => {
 
     // ── Settings & automation ─────────────────────────────────────────────────
     const { autoEndTurn, setAutoEndTurn, autoDontNeigh, setAutoDontNeigh } = useGameSettings();
+    const { sandboxAction, setSandboxAction } = useSandboxControl();
 
     // ── Computed ──────────────────────────────────────────────────────────────
     const boardStates = getBoardState(G, ctx, playerID);
@@ -209,6 +213,20 @@ const MobileBoard = ({ G, ctx, playerID, moves }: Props) => {
 
     /** Tap on any stable card (own or opponent) */
     const handleStableCardTap = (cardID: CardID) => {
+        // Sandbox interactive actions take priority
+        if (sandboxAction) {
+            if (sandboxAction.type === 'bounce') {
+                moves.sandboxBounceCard(cardID);
+                setSandboxAction(null);
+            } else if (sandboxAction.type === 'destroy') {
+                moves.sandboxDestroyCard(cardID);
+                setSandboxAction(null);
+            } else if (sandboxAction.type === 'steal' && sandboxAction.step === 'pick_card') {
+                setSandboxAction({ type: 'steal', step: 'pick_target', cardID });
+            }
+            return;
+        }
+
         // If in click_on_other_stable_card mode and card is a valid target → execute
         if (
             (cardInteraction?.key === 'click_on_other_stable_card' || cardInteraction?.key === 'card_to_card') &&
@@ -396,6 +414,17 @@ const MobileBoard = ({ G, ctx, playerID, moves }: Props) => {
     /** Tap on a hand card (non-drag, second tap on peeked = play) */
     const handleHandCardTap = (cardID: CardID) => {
         const card = G.deck[cardID];
+
+        // Sandbox interactive actions
+        if (sandboxAction) {
+            if (sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_card') {
+                setSandboxAction({ type: 'move_to_stable', step: 'pick_stable', cardID });
+            } else if (sandboxAction.type === 'force_discard') {
+                moves.sandboxForceDiscardCard(sandboxAction.playerID, cardID);
+                setSandboxAction(null);
+            }
+            return;
+        }
 
         // Neigh discussion
         if (boardStates.find(s => s.type === 'neigh__playNeigh')) {
@@ -621,6 +650,12 @@ const MobileBoard = ({ G, ctx, playerID, moves }: Props) => {
                     onCardLongPress={card => setDetailCard(card)}
                 />
             </Wrapper>
+            {G.sandbox && (
+                <>
+                    <SandboxActionBanner />
+                    <SandboxPanel G={G} ctx={ctx} moves={moves as any} playerID={playerID} />
+                </>
+            )}
         </AnimateSharedLayout>
     );
 };

--- a/src/mobile/MobileBoard.tsx
+++ b/src/mobile/MobileBoard.tsx
@@ -69,7 +69,11 @@ const MobileBoard = ({ G, ctx, playerID, moves }: Props) => {
 
     // ── Computed ──────────────────────────────────────────────────────────────
     const boardStates = getBoardState(G, ctx, playerID);
-    useAutoActions(G, ctx, playerID, moves, { autoEndTurn, autoDontNeigh }, boardStates);
+    const isSandboxDummy = G.sandbox === true && playerID !== G.owner;
+    useAutoActions(G, ctx, playerID, moves, {
+        autoEndTurn: isSandboxDummy ? false : autoEndTurn,
+        autoDontNeigh: isSandboxDummy ? false : autoDontNeigh,
+    }, boardStates);
 
     let openScenes: Array<[Instruction, Scene]> = _findInProgressScenesWithProtagonist(G, playerID);
     if (openScenes.length === 0) {

--- a/src/sandbox/SandboxActionBanner.tsx
+++ b/src/sandbox/SandboxActionBanner.tsx
@@ -1,0 +1,73 @@
+import styled from 'styled-components';
+import { useSandboxControl } from './sandboxContext';
+import type { SandboxAction } from './sandboxContext';
+
+function getActionText(action: SandboxAction): string | null {
+    if (!action) return null;
+    switch (action.type) {
+        case 'bounce': return 'Click on a card in any stable to bounce it to hand';
+        case 'destroy': return 'Click on a card in any stable to destroy it';
+        case 'steal':
+            return action.step === 'pick_card'
+                ? 'Click on a card in any stable to steal'
+                : 'Choose target player in the Sandbox panel';
+        case 'move_to_stable':
+            return action.step === 'pick_card'
+                ? 'Click on a card in your hand to move it to a stable'
+                : 'Choose target stable in the Sandbox panel';
+        case 'force_discard':
+            return 'Pick a card to discard in the Sandbox panel';
+        default: return null;
+    }
+}
+
+const SandboxActionBanner = () => {
+    const { sandboxAction, setSandboxAction } = useSandboxControl();
+    const text = getActionText(sandboxAction);
+    if (!text) return null;
+
+    return (
+        <Banner>
+            <BannerText>{text}</BannerText>
+            <CancelBtn onClick={() => setSandboxAction(null)}>Cancel</CancelBtn>
+        </Banner>
+    );
+};
+
+const Banner = styled.div`
+    position: fixed;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 8000;
+    background: linear-gradient(135deg, #2a1a4e 0%, #1a0f35 100%);
+    border: 2px solid #7c4dff;
+    border-top: none;
+    border-radius: 0 0 12px 12px;
+    padding: 10px 20px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    box-shadow: 0 4px 20px rgba(124, 77, 255, 0.3);
+`;
+
+const BannerText = styled.span`
+    color: #e0d0ff;
+    font-size: 13px;
+    font-weight: 600;
+`;
+
+const CancelBtn = styled.button`
+    background: #3a1a1a;
+    color: #ff8080;
+    border: 1px solid #6a2a2a;
+    border-radius: 5px;
+    padding: 4px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+    &:hover { background: #5a2020; }
+`;
+
+export default SandboxActionBanner;

--- a/src/sandbox/SandboxClient.tsx
+++ b/src/sandbox/SandboxClient.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { Client } from 'boardgame.io/react';
+import { Local } from 'boardgame.io/multiplayer';
+import type { Ctx } from 'boardgame.io';
+import Board from '../Board';
+import UnstableUnicorns from '../game/game';
+import { SandboxControlContext } from './sandboxContext';
+import type { SandboxAction } from './sandboxContext';
+
+const SandboxGame = {
+    ...UnstableUnicorns,
+    setup: (ctx: Ctx) =>
+        (UnstableUnicorns as any).setup(ctx, { sandbox: true, ownerPlayerID: "0" }),
+};
+
+const SandboxBoardgameClient = Client({
+    game: SandboxGame,
+    board: Board as any,
+    numPlayers: 3,
+    debug: false,
+    multiplayer: Local(),
+});
+
+const SandboxClient = () => {
+    const [viewedPlayerID, setViewedPlayerID] = useState("0");
+    const [sandboxAction, setSandboxAction] = useState<SandboxAction>(null);
+
+    return (
+        <SandboxControlContext.Provider value={{ viewedPlayerID, setViewedPlayerID, sandboxAction, setSandboxAction }}>
+            {["0", "1", "2"].map(pid => (
+                <div key={pid} style={{ display: viewedPlayerID === pid ? 'contents' : 'none' }}>
+                    <SandboxBoardgameClient matchID="sandbox" playerID={pid} />
+                </div>
+            ))}
+        </SandboxControlContext.Provider>
+    );
+};
+
+export default SandboxClient;

--- a/src/sandbox/SandboxClient.tsx
+++ b/src/sandbox/SandboxClient.tsx
@@ -11,6 +11,14 @@ const SandboxGame = {
     ...UnstableUnicorns,
     setup: (ctx: Ctx) =>
         (UnstableUnicorns as any).setup(ctx, { sandbox: true, ownerPlayerID: "0" }),
+    turn: {
+        ...(UnstableUnicorns as any).turn,
+        order: {
+            playOrder: () => ["0", "1", "2"],
+            first: () => 0,
+            next: (_G: any, ctx: any) => (ctx.playOrderPos + 1) % ctx.numPlayers,
+        },
+    },
 };
 
 const SandboxBoardgameClient = Client({

--- a/src/sandbox/SandboxPanel.tsx
+++ b/src/sandbox/SandboxPanel.tsx
@@ -1,0 +1,962 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import styled from 'styled-components';
+import type { UnstableUnicornsGame, Ctx } from '../game/state';
+import type { Moves } from '../game/types';
+import { Cards, hasType } from '../game/card';
+import type { CardDefinition } from '../game/card';
+import { CONSTANTS } from '../game/constants';
+import { KNOWN_EFFECTS } from '../game/effect';
+import type { Effect } from '../game/effect';
+import ImageLoader from '../assets/card/imageLoader';
+import { serializeSandboxSnapshot } from '../game/sandbox/sandboxMoves';
+import { useSandboxControl } from './sandboxContext';
+
+type Props = {
+    G: UnstableUnicornsGame;
+    ctx: Ctx;
+    moves: Moves;
+    playerID: string;
+};
+
+type TargetPlayer = "0" | "1" | "2";
+const PLAYER_LABELS: Record<TargetPlayer, string> = {
+    "0": "Player",
+    "1": "Dummy 1",
+    "2": "Dummy 2",
+};
+
+// ─── Fuzzy search ─────────────────────────────────────────────────────────────
+
+function fuzzyMatch(query: string, title: string): boolean {
+    const q = query.toLowerCase();
+    const t = title.toLowerCase();
+    if (t.includes(q)) return true;
+    let qi = 0;
+    for (let i = 0; i < t.length && qi < q.length; i++) {
+        if (t[i] === q[qi]) qi++;
+    }
+    return qi === q.length;
+}
+
+const LS_AUTO_SKIP = "sandbox_autoSkip";
+const LS_EXPANDED = "sandbox_expanded";
+const LS_RECENT = "sandbox_recentPicks";
+const LS_SLOTS = "sandbox_slots";
+
+function loadBool(key: string, def: boolean): boolean {
+    try { const v = localStorage.getItem(key); return v === null ? def : v === "true"; } catch { return def; }
+}
+function saveBool(key: string, v: boolean) {
+    try { localStorage.setItem(key, String(v)); } catch {}
+}
+function loadJSON<T>(key: string, def: T): T {
+    try { const v = localStorage.getItem(key); return v ? JSON.parse(v) : def; } catch { return def; }
+}
+function saveJSON(key: string, v: any) {
+    try { localStorage.setItem(key, JSON.stringify(v)); } catch {}
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+const SandboxPanel = ({ G, ctx, moves, playerID }: Props) => {
+    const [open, setOpen] = useState(() => loadBool(LS_EXPANDED, true));
+    const [autoSkip, setAutoSkip] = useState(() => loadBool(LS_AUTO_SKIP, true));
+    const [targetPlayer, setTargetPlayer] = useState<TargetPlayer>("0");
+    const { viewedPlayerID, setViewedPlayerID, sandboxAction, setSandboxAction } = useSandboxControl();
+
+    // Search state
+    const [searchQuery, setSearchQuery] = useState("");
+    const [searchResults, setSearchResults] = useState<{ def: CardDefinition; defIndex: number }[]>([]);
+    const [selectedResult, setSelectedResult] = useState<{ def: CardDefinition; defIndex: number } | null>(null);
+    const [recentPicks, setRecentPicks] = useState<number[]>(() => loadJSON(LS_RECENT, []));
+
+    // Effects
+    const [selectedEffect, setSelectedEffect] = useState<Effect["key"]>(KNOWN_EFFECTS[0]);
+
+    // Inspect
+    const [showRawG, setShowRawG] = useState(false);
+
+    // Save/Load
+    const [slots, setSlots] = useState<(string | null)[]>(() => loadJSON(LS_SLOTS, [null, null, null]));
+
+    // Toggle persistence
+    const toggleOpen = () => setOpen(v => { saveBool(LS_EXPANDED, !v); return !v; });
+    const toggleAutoSkip = () => setAutoSkip(v => { saveBool(LS_AUTO_SKIP, !v); return !v; });
+
+    // Auto-skip dummy turns
+    const autoSkipRef = useRef(autoSkip);
+    autoSkipRef.current = autoSkip;
+    useEffect(() => {
+        if (!autoSkipRef.current) return;
+        if (ctx.currentPlayer === playerID) return;
+        if (G.neighDiscussion) return;
+        const pendingScenes = G.script?.scenes?.filter(s =>
+            s.actions.some(a => a.instructions.some(i => i.protagonist === ctx.currentPlayer && (i.state === "open" || i.state === "in_progress")))
+        );
+        if (pendingScenes && pendingScenes.length > 0) return;
+        const timer = setTimeout(() => {
+            if (autoSkipRef.current && ctx.currentPlayer !== playerID) {
+                moves.sandboxForceEndTurn();
+            }
+        }, 200);
+        return () => clearTimeout(timer);
+    }, [ctx.currentPlayer, ctx.turn, G.neighDiscussion, G.script]);
+
+    // Belt-and-braces: auto-resolve any neigh discussion that sneaks through when skipNeigh is on
+    useEffect(() => {
+        if (!G.neighDiscussion) return;
+        if (!G.sandboxSettings?.skipNeigh) return;
+        moves.sandboxResolveNeighAsPlayed();
+    }, [G.neighDiscussion]);
+
+    // Keyboard shortcut
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.ctrlKey && e.key === '\\') { e.preventDefault(); toggleOpen(); }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, []);
+
+    // Search
+    useEffect(() => {
+        if (!searchQuery.trim()) {
+            setSearchResults([]);
+            return;
+        }
+        const results: { def: CardDefinition; defIndex: number }[] = [];
+        const seen = new Set<string>();
+        Cards.forEach((def, idx) => {
+            if (seen.has(def.title)) return;
+            if (fuzzyMatch(searchQuery, def.title) || fuzzyMatch(searchQuery, Array.isArray(def.type) ? def.type.join(' ') : def.type)) {
+                seen.add(def.title);
+                results.push({ def, defIndex: idx });
+            }
+        });
+        setSearchResults(results.slice(0, 12));
+    }, [searchQuery]);
+
+    const addRecentPick = useCallback((defIndex: number) => {
+        setRecentPicks(prev => {
+            const next = [defIndex, ...prev.filter(i => i !== defIndex)].slice(0, 8);
+            saveJSON(LS_RECENT, next);
+            return next;
+        });
+    }, []);
+
+    // Quick-action helpers
+    const randomDefOf = (filter: (d: CardDefinition) => boolean): number | null => {
+        const candidates = Cards.reduce<number[]>((acc, d, i) => { if (filter(d)) acc.push(i); return acc; }, []);
+        if (!candidates.length) return null;
+        return candidates[Math.floor(Math.random() * candidates.length)];
+    };
+
+    const drawToHandSize = (pid: string) => {
+        const count = Math.max(0, CONSTANTS.numberOfHandCardsAtStart - G.hand[pid].length);
+        if (count > 0) moves.sandboxDraw(pid, count);
+    };
+
+    // Destination picker for search results
+    type Dest = "hand" | "stable_enter" | "stable_silent" | "discard" | "deck_top" | "nursery";
+    const dispatchToDestination = (defIndex: number, dest: Dest, pid: TargetPlayer) => {
+        addRecentPick(defIndex);
+        switch (dest) {
+            case "hand": moves.sandboxAddToHand(pid, defIndex); break;
+            case "stable_enter": moves.sandboxAddToStable(pid, defIndex, true); break;
+            case "stable_silent": moves.sandboxAddToStable(pid, defIndex, false); break;
+            case "discard": moves.sandboxAddToDiscard(defIndex); break;
+            case "deck_top": moves.sandboxAddToDeckTop(defIndex); break;
+            case "nursery": moves.sandboxAddToNursery(defIndex); break;
+        }
+        setSelectedResult(null);
+        setSearchQuery("");
+    };
+
+    // Save/Load
+    const saveSlot = (i: number) => {
+        const snap = JSON.stringify(serializeSandboxSnapshot(G));
+        const next = [...slots];
+        next[i] = snap;
+        setSlots(next);
+        saveJSON(LS_SLOTS, next);
+    };
+    const loadSlot = (i: number) => {
+        if (!slots[i]) return;
+        try {
+            const snap = JSON.parse(slots[i]!);
+            moves.sandboxLoadState(snap);
+        } catch {}
+    };
+    const clearSlot = (i: number) => {
+        const next = [...slots];
+        next[i] = null;
+        setSlots(next);
+        saveJSON(LS_SLOTS, next);
+    };
+    const copyToClipboard = () => {
+        const text = JSON.stringify(serializeSandboxSnapshot(G), null, 2);
+        navigator.clipboard.writeText(text).catch(() => {});
+    };
+    const pasteFromClipboard = async () => {
+        try {
+            const text = await navigator.clipboard.readText();
+            const snap = JSON.parse(text);
+            moves.sandboxLoadState(snap);
+        } catch {}
+    };
+
+    return (
+        <>
+            <ToggleButton onClick={toggleOpen} title="Toggle Sandbox Panel (Ctrl+\)">
+                {open ? '»' : '«'}
+            </ToggleButton>
+            {open && (
+                <Drawer>
+                    <DrawerHeader>
+                        <DrawerTitle>Sandbox</DrawerTitle>
+                        <SkipToggle active={autoSkip} onClick={toggleAutoSkip} title="Auto-skip dummy turns">
+                            {autoSkip ? 'Auto-skip ON' : 'Auto-skip OFF'}
+                        </SkipToggle>
+                    </DrawerHeader>
+
+                    <PlayerPills>
+                        {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                            <PlayerPill key={pid} active={targetPlayer === pid} onClick={() => setTargetPlayer(pid)}>
+                                {PLAYER_LABELS[pid]}
+                            </PlayerPill>
+                        ))}
+                    </PlayerPills>
+
+                    <DrawerBody>
+                        {/* ── Settings ── */}
+                        <Section>
+                            <SectionTitle>Settings</SectionTitle>
+                            <SettingRow>
+                                <SettingLabel>Infinite actions / draws</SettingLabel>
+                                <ToggleSwitch
+                                    active={G.sandboxSettings?.infiniteActions ?? false}
+                                    onClick={() => moves.sandboxSetSetting("infiniteActions", !(G.sandboxSettings?.infiniteActions))}
+                                />
+                            </SettingRow>
+                            <SettingRow>
+                                <SettingLabel>Auto-resolve Neigh</SettingLabel>
+                                <ToggleSwitch
+                                    active={G.sandboxSettings?.skipNeigh ?? false}
+                                    onClick={() => moves.sandboxSetSetting("skipNeigh", !(G.sandboxSettings?.skipNeigh))}
+                                />
+                            </SettingRow>
+                        </Section>
+
+                        {/* ── Seat ── */}
+                        <Section>
+                            <SectionTitle>View as</SectionTitle>
+                            <PlayerPills>
+                                {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                                    <PlayerPill key={pid} active={viewedPlayerID === pid} onClick={() => setViewedPlayerID(pid)}>
+                                        {PLAYER_LABELS[pid]}
+                                    </PlayerPill>
+                                ))}
+                            </PlayerPills>
+                            <InfoLine style={{ marginTop: 4 }}>Swapping seat remounts the board — G is unchanged.</InfoLine>
+                        </Section>
+
+                        {/* ── Quick Actions ── */}
+                        <Section>
+                            <SectionTitle>Quick Actions — {PLAYER_LABELS[targetPlayer]}</SectionTitle>
+                            <ButtonGrid>
+                                <CheatBtn onClick={() => {
+                                    const i = randomDefOf(d => hasType({ type: d.type }, 'basic'));
+                                    if (i != null) moves.sandboxAddToStable(targetPlayer, i, false);
+                                }}>+ Basic Unicorn (silent)</CheatBtn>
+                                <CheatBtn onClick={() => {
+                                    const i = randomDefOf(d => hasType({ type: d.type }, 'unicorn') && !hasType({ type: d.type }, 'baby'));
+                                    if (i != null) moves.sandboxAddToStable(targetPlayer, i, false);
+                                }}>+ Magical Unicorn (silent)</CheatBtn>
+                                <CheatBtn onClick={() => {
+                                    const i = randomDefOf(d => hasType({ type: d.type }, 'unicorn') && !hasType({ type: d.type }, 'baby'));
+                                    if (i != null) moves.sandboxAddToStable(targetPlayer, i, true);
+                                }}>+ Magical Unicorn (enter)</CheatBtn>
+                                <CheatBtn onClick={() => moves.sandboxDraw(targetPlayer, 1)}>Draw 1</CheatBtn>
+                                <CheatBtn onClick={() => moves.sandboxDraw(targetPlayer, 5)}>Draw 5</CheatBtn>
+                                <CheatBtn onClick={() => drawToHandSize(targetPlayer)}>Draw to hand size</CheatBtn>
+                                <CheatBtn onClick={() => moves.sandboxDiscardRandom(targetPlayer)}>Discard random</CheatBtn>
+                                <CheatBtn onClick={() => moves.sandboxEmptyHand(targetPlayer)}>Empty hand</CheatBtn>
+                            </ButtonGrid>
+                            <ButtonGrid style={{ marginTop: 6 }}>
+                                <CheatBtn onClick={() => moves.sandboxForceEndTurn()}>End turn</CheatBtn>
+                                <CheatBtn onClick={() => {
+                                    moves.sandboxForceEndTurn();
+                                    setTimeout(() => moves.sandboxForceEndTurn(), 50);
+                                    setTimeout(() => moves.sandboxForceEndTurn(), 100);
+                                }}>End turn ×3</CheatBtn>
+                                <CheatBtn onClick={() => moves.sandboxReshuffleDiscard()}>Reshuffle discard</CheatBtn>
+                            </ButtonGrid>
+                        </Section>
+
+                        {/* ── Interactive Actions ── */}
+                        <Section>
+                            <SectionTitle>Interactive Actions</SectionTitle>
+                            {!sandboxAction ? (
+                                <ButtonGrid>
+                                    <ActionBtn onClick={() => setSandboxAction({ type: 'bounce' })}>Bounce card</ActionBtn>
+                                    <ActionBtn onClick={() => setSandboxAction({ type: 'destroy' })}>Destroy card</ActionBtn>
+                                    <ActionBtn onClick={() => setSandboxAction({ type: 'steal', step: 'pick_card' })}>Steal card</ActionBtn>
+                                    <ActionBtn onClick={() => setSandboxAction({ type: 'move_to_stable', step: 'pick_card' })}>Hand → Stable</ActionBtn>
+                                    <ActionBtn onClick={() => setSandboxAction({ type: 'force_discard', playerID: targetPlayer })}>Force discard</ActionBtn>
+                                </ButtonGrid>
+                            ) : (
+                                <ActionActiveBox>
+                                    {sandboxAction.type === 'steal' && sandboxAction.step === 'pick_target' && (
+                                        <>
+                                            <ActionLabel>Steal "{G.deck[sandboxAction.cardID]?.title}" → move to:</ActionLabel>
+                                            <ButtonGrid>
+                                                {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                                                    <SmallCheatBtn key={pid} onClick={() => {
+                                                        if (sandboxAction.type === 'steal' && sandboxAction.step === 'pick_target') {
+                                                            moves.sandboxStealCard(sandboxAction.cardID, pid);
+                                                        }
+                                                        setSandboxAction(null);
+                                                    }}>{PLAYER_LABELS[pid]}'s stable</SmallCheatBtn>
+                                                ))}
+                                            </ButtonGrid>
+                                        </>
+                                    )}
+                                    {sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_stable' && (
+                                        <>
+                                            <ActionLabel>Place "{G.deck[sandboxAction.cardID]?.title}" into:</ActionLabel>
+                                            <ButtonGrid>
+                                                {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                                                    <SmallCheatBtn key={pid} onClick={() => {
+                                                        if (sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_stable') {
+                                                            moves.sandboxHandToStable(sandboxAction.cardID, pid);
+                                                        }
+                                                        setSandboxAction(null);
+                                                    }}>{PLAYER_LABELS[pid]}'s stable</SmallCheatBtn>
+                                                ))}
+                                            </ButtonGrid>
+                                        </>
+                                    )}
+                                    {sandboxAction.type === 'force_discard' && (
+                                        <>
+                                            <ActionLabel>Pick a card from {PLAYER_LABELS[sandboxAction.playerID as TargetPlayer]}'s hand to discard:</ActionLabel>
+                                            <HandPickerList>
+                                                {G.hand[sandboxAction.playerID]?.map(cardID => {
+                                                    const card = G.deck[cardID];
+                                                    if (!card) return null;
+                                                    return (
+                                                        <ResultItem key={cardID} onClick={() => {
+                                                            if (sandboxAction.type === 'force_discard') {
+                                                                moves.sandboxForceDiscardCard(sandboxAction.playerID, cardID);
+                                                            }
+                                                            setSandboxAction(null);
+                                                        }}>
+                                                            <ResultThumb src={ImageLoader.load(card.image)} alt={card.title} />
+                                                            <ResultInfo>
+                                                                <ResultTitle>{card.title}</ResultTitle>
+                                                                <ResultType>{Array.isArray(card.type) ? card.type.join(', ') : card.type}</ResultType>
+                                                            </ResultInfo>
+                                                        </ResultItem>
+                                                    );
+                                                })}
+                                                {(!G.hand[sandboxAction.playerID] || G.hand[sandboxAction.playerID].length === 0) && (
+                                                    <EmptyChips>Hand is empty</EmptyChips>
+                                                )}
+                                            </HandPickerList>
+                                        </>
+                                    )}
+                                    {sandboxAction.type !== 'force_discard' &&
+                                     !(sandboxAction.type === 'steal' && sandboxAction.step === 'pick_target') &&
+                                     !(sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_stable') && (
+                                        <ActionLabel>
+                                            {sandboxAction.type === 'bounce' && 'Click a card in any stable on the board...'}
+                                            {sandboxAction.type === 'destroy' && 'Click a card in any stable on the board...'}
+                                            {sandboxAction.type === 'steal' && sandboxAction.step === 'pick_card' && 'Click a card in any stable on the board...'}
+                                            {sandboxAction.type === 'move_to_stable' && sandboxAction.step === 'pick_card' && 'Click a card in your hand on the board...'}
+                                        </ActionLabel>
+                                    )}
+                                    <CancelBtn onClick={() => setSandboxAction(null)}>Cancel</CancelBtn>
+                                </ActionActiveBox>
+                            )}
+                        </Section>
+
+                        {/* ── Card Search ── */}
+                        <Section>
+                            <SectionTitle>Add Card (Search)</SectionTitle>
+                            <SearchInput
+                                placeholder="Search cards…"
+                                value={searchQuery}
+                                onChange={e => { setSearchQuery(e.target.value); setSelectedResult(null); }}
+                            />
+
+                            {/* Recent picks */}
+                            {!searchQuery && recentPicks.length > 0 && (
+                                <>
+                                    <SmallLabel>Recent</SmallLabel>
+                                    <ResultList>
+                                        {recentPicks.map(idx => {
+                                            const def = Cards[idx];
+                                            if (!def) return null;
+                                            return (
+                                                <ResultItem key={idx} onClick={() => setSelectedResult({ def, defIndex: idx })}>
+                                                    <ResultThumb src={ImageLoader.load(def.image)} alt={def.title} />
+                                                    <ResultInfo>
+                                                        <ResultTitle>{def.title}</ResultTitle>
+                                                        <ResultType>{Array.isArray(def.type) ? def.type.join(', ') : def.type}</ResultType>
+                                                    </ResultInfo>
+                                                </ResultItem>
+                                            );
+                                        })}
+                                    </ResultList>
+                                </>
+                            )}
+
+                            {/* Search results */}
+                            {searchResults.length > 0 && (
+                                <ResultList>
+                                    {searchResults.map(({ def, defIndex }) => (
+                                        <ResultItem key={defIndex} onClick={() => setSelectedResult({ def, defIndex })}>
+                                            <ResultThumb src={ImageLoader.load(def.image)} alt={def.title} />
+                                            <ResultInfo>
+                                                <ResultTitle>{def.title}</ResultTitle>
+                                                <ResultType>{Array.isArray(def.type) ? def.type.join(', ') : def.type}</ResultType>
+                                            </ResultInfo>
+                                        </ResultItem>
+                                    ))}
+                                </ResultList>
+                            )}
+
+                            {/* Destination picker */}
+                            {selectedResult && (
+                                <DestPicker>
+                                    <DestTitle>"{selectedResult.def.title}" → where?</DestTitle>
+                                    <DestGrid>
+                                        {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                                            <DestGroup key={pid}>
+                                                <DestGroupLabel>{PLAYER_LABELS[pid]}</DestGroupLabel>
+                                                <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "hand", pid)}>Hand</SmallCheatBtn>
+                                                <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "stable_enter", pid)}>Stable (enter)</SmallCheatBtn>
+                                                <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "stable_silent", pid)}>Stable (silent)</SmallCheatBtn>
+                                            </DestGroup>
+                                        ))}
+                                        <DestGroup>
+                                            <DestGroupLabel>Zones</DestGroupLabel>
+                                            <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "discard", targetPlayer)}>Discard</SmallCheatBtn>
+                                            <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "deck_top", targetPlayer)}>Top of Deck</SmallCheatBtn>
+                                            <SmallCheatBtn onClick={() => dispatchToDestination(selectedResult.defIndex, "nursery", targetPlayer)}>Nursery</SmallCheatBtn>
+                                        </DestGroup>
+                                    </DestGrid>
+                                    <CancelBtn onClick={() => setSelectedResult(null)}>Cancel</CancelBtn>
+                                </DestPicker>
+                            )}
+                        </Section>
+
+                        {/* ── Effects ── */}
+                        <Section>
+                            <SectionTitle>Effects</SectionTitle>
+                            {(["0", "1", "2"] as TargetPlayer[]).map(pid => (
+                                <div key={pid} style={{ marginBottom: 8 }}>
+                                    <SmallLabel>{PLAYER_LABELS[pid]}</SmallLabel>
+                                    <EffectChips>
+                                        {G.playerEffects[pid]?.map((e, idx) => (
+                                            <EffectChip key={idx}>
+                                                {e.effect.key}
+                                                <ChipRemove onClick={() => moves.sandboxRemoveEffect(pid, idx)}>✕</ChipRemove>
+                                            </EffectChip>
+                                        ))}
+                                        {(!G.playerEffects[pid] || G.playerEffects[pid].length === 0) && (
+                                            <EmptyChips>none</EmptyChips>
+                                        )}
+                                    </EffectChips>
+                                </div>
+                            ))}
+                            <EffectAddRow>
+                                <EffectSelect value={selectedEffect} onChange={e => setSelectedEffect(e.target.value as Effect["key"])}>
+                                    {KNOWN_EFFECTS.map(k => <option key={k} value={k}>{k}</option>)}
+                                </EffectSelect>
+                                <SmallCheatBtn onClick={() => moves.sandboxAddEffect(targetPlayer, selectedEffect)}>
+                                    Add to {PLAYER_LABELS[targetPlayer]}
+                                </SmallCheatBtn>
+                            </EffectAddRow>
+                            <DangerBtn onClick={() => moves.sandboxClearAllEffects()} style={{ marginTop: 6 }}>
+                                Clear all effects
+                            </DangerBtn>
+                        </Section>
+
+                        {/* ── Flow ── */}
+                        <Section>
+                            <SectionTitle>Flow</SectionTitle>
+                            <ButtonGrid>
+                                <CheatBtn onClick={() => moves.sandboxCancelNeigh()}>Cancel Neigh</CheatBtn>
+                                <DangerBtn onClick={() => moves.sandboxClearSceneQueue()} title="May strand cards mid-resolution">
+                                    Clear scene queue
+                                </DangerBtn>
+                            </ButtonGrid>
+                            <InfoLine>Turn: {ctx.turn} | Current: {G.players[parseInt(ctx.currentPlayer)]?.name ?? ctx.currentPlayer}</InfoLine>
+                            <InfoLine>Stage: {ctx.activePlayers ? Object.values(ctx.activePlayers)[0] ?? '—' : '—'}</InfoLine>
+                            <InfoLine>Scenes: {G.script?.scenes?.length ?? 0}</InfoLine>
+                        </Section>
+
+                        {/* ── Inspect ── */}
+                        <Section>
+                            <SectionTitle>Inspect</SectionTitle>
+                            <CheatBtn onClick={() => setShowRawG(v => !v)}>
+                                {showRawG ? 'Hide raw G' : 'Show raw G (JSON)'}
+                            </CheatBtn>
+                            {showRawG && (
+                                <RawG>
+                                    {JSON.stringify({
+                                        hand: G.hand,
+                                        stable: G.stable,
+                                        upgradeDowngradeStable: G.upgradeDowngradeStable,
+                                        playerEffects: G.playerEffects,
+                                        script: G.script,
+                                        neighDiscussion: G.neighDiscussion,
+                                        drawPile: G.drawPile.length + ' cards',
+                                        discardPile: G.discardPile.length + ' cards',
+                                    }, null, 2)}
+                                </RawG>
+                            )}
+                        </Section>
+
+                        {/* ── Save / Load ── */}
+                        <Section>
+                            <SectionTitle>Save / Load</SectionTitle>
+                            <ButtonGrid>
+                                <CheatBtn onClick={copyToClipboard}>Copy state</CheatBtn>
+                                <CheatBtn onClick={pasteFromClipboard}>Paste state</CheatBtn>
+                            </ButtonGrid>
+                            {(['A', 'B', 'C'] as const).map((label, i) => (
+                                <SlotRow key={label}>
+                                    <SlotLabel>Slot {label}</SlotLabel>
+                                    <SmallCheatBtn onClick={() => saveSlot(i)}>Save</SmallCheatBtn>
+                                    <SmallCheatBtn onClick={() => loadSlot(i)} disabled={!slots[i]}>Load</SmallCheatBtn>
+                                    <SmallCheatBtn onClick={() => clearSlot(i)} disabled={!slots[i]}>Clear</SmallCheatBtn>
+                                </SlotRow>
+                            ))}
+                        </Section>
+                    </DrawerBody>
+                </Drawer>
+            )}
+        </>
+    );
+};
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const ToggleButton = styled.button`
+    position: fixed;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 1001;
+    background: #2a1a4e;
+    color: #fff;
+    border: 1px solid #7c4dff;
+    border-right: none;
+    border-radius: 6px 0 0 6px;
+    padding: 8px 6px;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    transition: background 0.15s;
+    &:hover { background: #3d2970; }
+`;
+
+const Drawer = styled.div`
+    position: fixed;
+    right: 0;
+    top: 0;
+    height: 100vh;
+    width: 300px;
+    background: #1a0f35;
+    border-left: 2px solid #7c4dff;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    @media (max-width: 768px) {
+        width: 100vw;
+        height: 45vh;
+        top: auto;
+        bottom: 0;
+        border-left: none;
+        border-top: 2px solid #7c4dff;
+    }
+`;
+
+const DrawerHeader = styled.div`
+    padding: 10px 14px;
+    border-bottom: 1px solid #3d2970;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+`;
+
+const DrawerTitle = styled.span`
+    color: #c084fc;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    flex: 1;
+`;
+
+const SkipToggle = styled.button<{ active: boolean }>`
+    font-size: 10px;
+    padding: 3px 8px;
+    border-radius: 10px;
+    border: 1px solid ${p => p.active ? '#6BCB77' : '#555'};
+    background: ${p => p.active ? '#1a3a1e' : '#2a1a4e'};
+    color: ${p => p.active ? '#6BCB77' : '#888'};
+    cursor: pointer;
+    transition: all 0.15s;
+`;
+
+const PlayerPills = styled.div`
+    display: flex;
+    gap: 4px;
+    padding: 8px 14px;
+    border-bottom: 1px solid #2a1a4e;
+    flex-shrink: 0;
+`;
+
+const PlayerPill = styled.button<{ active: boolean }>`
+    flex: 1;
+    padding: 4px 0;
+    border-radius: 12px;
+    border: 1px solid ${p => p.active ? '#7c4dff' : '#3d2970'};
+    background: ${p => p.active ? '#3d2970' : 'transparent'};
+    color: ${p => p.active ? '#e0d0ff' : '#7060a0'};
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.12s;
+`;
+
+const DrawerBody = styled.div`
+    flex: 1;
+    overflow-y: auto;
+    padding-bottom: 16px;
+`;
+
+const Section = styled.div`
+    padding: 10px 14px 12px;
+    border-bottom: 1px solid #2a1a4e;
+`;
+
+const SectionTitle = styled.div`
+    color: #9d7fe0;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 8px;
+`;
+
+const SmallLabel = styled.div`
+    color: #6040a0;
+    font-size: 10px;
+    margin-bottom: 4px;
+`;
+
+const ButtonGrid = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+`;
+
+const baseBtn = `
+    border-radius: 5px;
+    padding: 5px 6px;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: center;
+    transition: all 0.12s;
+    border: 1px solid;
+    font-family: inherit;
+    line-height: 1.3;
+`;
+
+const CheatBtn = styled.button`
+    ${baseBtn}
+    background: #2a1a4e;
+    color: #c9b8f0;
+    border-color: #4a3570;
+    &:hover { background: #3d2970; border-color: #7c4dff; }
+    &:disabled { opacity: 0.4; cursor: default; }
+`;
+
+const SmallCheatBtn = styled(CheatBtn)`
+    padding: 3px 6px;
+    font-size: 10px;
+`;
+
+const DangerBtn = styled.button`
+    ${baseBtn}
+    background: #3a1a1a;
+    color: #ff8080;
+    border-color: #6a2a2a;
+    &:hover { background: #5a2020; }
+`;
+
+const CancelBtn = styled.button`
+    ${baseBtn}
+    background: transparent;
+    color: #7060a0;
+    border-color: #4a3570;
+    margin-top: 6px;
+    width: 100%;
+    &:hover { color: #ccc; }
+`;
+
+const SearchInput = styled.input`
+    width: 100%;
+    box-sizing: border-box;
+    background: #12092a;
+    border: 1px solid #4a3570;
+    border-radius: 5px;
+    color: #e0d0ff;
+    font-size: 12px;
+    padding: 5px 8px;
+    margin-bottom: 6px;
+    outline: none;
+    &:focus { border-color: #7c4dff; }
+`;
+
+const ResultList = styled.div`
+    max-height: 180px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+`;
+
+const ResultItem = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 6px;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #12092a;
+    border: 1px solid transparent;
+    &:hover { border-color: #7c4dff; background: #2a1a4e; }
+`;
+
+const ResultThumb = styled.img`
+    width: 28px;
+    height: 40px;
+    object-fit: cover;
+    border-radius: 3px;
+    flex-shrink: 0;
+`;
+
+const ResultInfo = styled.div`
+    flex: 1;
+    min-width: 0;
+`;
+
+const ResultTitle = styled.div`
+    color: #e0d0ff;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const ResultType = styled.div`
+    color: #7060a0;
+    font-size: 10px;
+`;
+
+const DestPicker = styled.div`
+    background: #12092a;
+    border: 1px solid #7c4dff;
+    border-radius: 6px;
+    padding: 10px;
+    margin-top: 6px;
+`;
+
+const DestTitle = styled.div`
+    color: #c084fc;
+    font-size: 11px;
+    font-weight: 600;
+    margin-bottom: 8px;
+`;
+
+const DestGrid = styled.div`
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+`;
+
+const DestGroup = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+`;
+
+const DestGroupLabel = styled.div`
+    color: #6040a0;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    margin-bottom: 2px;
+`;
+
+const EffectChips = styled.div`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 6px;
+`;
+
+const EffectChip = styled.span`
+    background: #2a1a4e;
+    border: 1px solid #4a3570;
+    border-radius: 10px;
+    color: #c084fc;
+    font-size: 10px;
+    padding: 2px 6px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+`;
+
+const ChipRemove = styled.button`
+    background: none;
+    border: none;
+    color: #ff8080;
+    cursor: pointer;
+    padding: 0;
+    font-size: 10px;
+    line-height: 1;
+`;
+
+const EmptyChips = styled.span`
+    color: #4a3570;
+    font-size: 10px;
+    font-style: italic;
+`;
+
+const EffectAddRow = styled.div`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+    flex-wrap: wrap;
+`;
+
+const EffectSelect = styled.select`
+    flex: 1;
+    min-width: 0;
+    background: #12092a;
+    border: 1px solid #4a3570;
+    border-radius: 5px;
+    color: #c9b8f0;
+    font-size: 10px;
+    padding: 3px 5px;
+`;
+
+const InfoLine = styled.div`
+    color: #6040a0;
+    font-size: 10px;
+    margin-top: 4px;
+`;
+
+const RawG = styled.pre`
+    background: #080415;
+    border: 1px solid #3a2060;
+    border-radius: 5px;
+    color: #9070c0;
+    font-size: 9px;
+    padding: 8px;
+    overflow: auto;
+    max-height: 200px;
+    margin-top: 6px;
+    white-space: pre-wrap;
+    word-break: break-all;
+`;
+
+const SlotRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 5px;
+`;
+
+const SlotLabel = styled.span`
+    color: #7060a0;
+    font-size: 11px;
+    width: 44px;
+    flex-shrink: 0;
+`;
+
+const SettingRow = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 0;
+`;
+
+const SettingLabel = styled.span`
+    color: #c9b8f0;
+    font-size: 11px;
+`;
+
+const ToggleSwitch = styled.button<{ active: boolean }>`
+    width: 36px;
+    height: 20px;
+    border-radius: 10px;
+    border: 1px solid ${p => p.active ? '#6BCB77' : '#4a3570'};
+    background: ${p => p.active ? '#1a3a1e' : '#2a1a4e'};
+    cursor: pointer;
+    position: relative;
+    flex-shrink: 0;
+    transition: all 0.15s;
+    &::after {
+        content: '';
+        position: absolute;
+        top: 3px;
+        left: ${p => p.active ? '17px' : '3px'};
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: ${p => p.active ? '#6BCB77' : '#7060a0'};
+        transition: left 0.15s;
+    }
+`;
+
+const ActionBtn = styled(CheatBtn)`
+    background: #1a2a4e;
+    border-color: #3a5a8a;
+    color: #90c0ff;
+    &:hover { background: #253a6a; border-color: #5080cc; }
+`;
+
+const ActionActiveBox = styled.div`
+    background: #12092a;
+    border: 1px solid #7c4dff;
+    border-radius: 6px;
+    padding: 10px;
+`;
+
+const ActionLabel = styled.div`
+    color: #c084fc;
+    font-size: 11px;
+    font-weight: 600;
+    margin-bottom: 8px;
+`;
+
+const HandPickerList = styled.div`
+    max-height: 200px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    margin-bottom: 8px;
+`;
+
+export default SandboxPanel;

--- a/src/sandbox/SandboxPanel.tsx
+++ b/src/sandbox/SandboxPanel.tsx
@@ -89,6 +89,7 @@ const SandboxPanel = ({ G, ctx, moves, playerID }: Props) => {
     useEffect(() => {
         if (!autoSkipRef.current) return;
         if (ctx.currentPlayer === playerID) return;
+        if (playerID !== G.owner) return; // only owner panel drives auto-skip
         if (G.neighDiscussion) return;
         const pendingScenes = G.script?.scenes?.filter(s =>
             s.actions.some(a => a.instructions.some(i => i.protagonist === ctx.currentPlayer && (i.state === "open" || i.state === "in_progress")))
@@ -104,6 +105,7 @@ const SandboxPanel = ({ G, ctx, moves, playerID }: Props) => {
 
     // Belt-and-braces: auto-resolve any neigh discussion that sneaks through when skipNeigh is on
     useEffect(() => {
+        if (playerID !== G.owner) return; // only owner panel resolves neigh
         if (!G.neighDiscussion) return;
         if (!G.sandboxSettings?.skipNeigh) return;
         moves.sandboxResolveNeighAsPlayed();
@@ -574,13 +576,13 @@ const Drawer = styled.div`
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    @media (max-width: 768px) {
-        width: 100vw;
-        height: 45vh;
-        top: auto;
-        bottom: 0;
-        border-left: none;
-        border-top: 2px solid #7c4dff;
+    @media (pointer: coarse) {
+        width: 33vw;
+        height: 100vh;
+        top: 0;
+        bottom: auto;
+        border-left: 2px solid #7c4dff;
+        border-top: none;
     }
 `;
 
@@ -638,6 +640,9 @@ const DrawerBody = styled.div`
     flex: 1;
     overflow-y: auto;
     padding-bottom: 16px;
+    @media (pointer: coarse) {
+        font-size: 10px;
+    }
 `;
 
 const Section = styled.div`
@@ -664,6 +669,9 @@ const ButtonGrid = styled.div`
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 4px;
+    @media (pointer: coarse) {
+        grid-template-columns: 1fr;
+    }
 `;
 
 const baseBtn = `

--- a/src/sandbox/sandboxContext.ts
+++ b/src/sandbox/sandboxContext.ts
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+import type { CardID } from '../game/card';
+
+export type SandboxAction =
+    | { type: 'bounce' }
+    | { type: 'destroy' }
+    | { type: 'steal'; step: 'pick_card' }
+    | { type: 'steal'; step: 'pick_target'; cardID: CardID }
+    | { type: 'move_to_stable'; step: 'pick_card' }
+    | { type: 'move_to_stable'; step: 'pick_stable'; cardID: CardID }
+    | { type: 'force_discard'; playerID: string }
+    | null;
+
+type SandboxControl = {
+    viewedPlayerID: string;
+    setViewedPlayerID: (pid: string) => void;
+    sandboxAction: SandboxAction;
+    setSandboxAction: (action: SandboxAction) => void;
+};
+
+export const SandboxControlContext = createContext<SandboxControl>({
+    viewedPlayerID: "0",
+    setViewedPlayerID: () => {},
+    sandboxAction: null,
+    setSandboxAction: () => {},
+});
+
+export function useSandboxControl(): SandboxControl {
+    return useContext(SandboxControlContext);
+}


### PR DESCRIPTION
This pull request introduces a new "sandbox" mode for the Unstable Unicorns game, allowing for easier testing and debugging by bypassing certain game restrictions and adding developer controls to the UI. The changes span both the game logic and the frontend, integrating new sandbox-specific behaviors and UI panels.

**Key changes include:**

### Sandbox Mode Implementation

* Added a sandbox mode in `game.js` that, when enabled, pre-assigns baby unicorns, skips the pregame phase, and sets special settings like infinite actions and skipping Neigh checks. [[1]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437R27-R32) [[2]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437R56-R68) [[3]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437L68-R102) [[4]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437L97-R125)
* Integrated sandbox overrides in game logic to allow unlimited actions per turn and to bypass Neigh mechanics when appropriate. [[1]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437L224-R271) [[2]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437L260-R295) [[3]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437R380-R383) [[4]](diffhunk://#diff-b879ed55ecd4c3a2bbbc499983e2d6a572cee7de598600338835615e2ac8a437R404-R408) [[5]](diffhunk://#diff-569c3fd06fea886f8fb61cec00ee20a71164a0f594fa9e381b1e444ba95c25aaR4) [[6]](diffhunk://#diff-569c3fd06fea886f8fb61cec00ee20a71164a0f594fa9e381b1e444ba95c25aaR75-R91)

### Frontend Integration

* Added a new `SandboxClient` route and components (`SandboxPanel`, `SandboxActionBanner`) to the UI, which are conditionally rendered when sandbox mode is active. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R4) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R14-R16) [[3]](diffhunk://#diff-ca18eda25e1a814b3a2fa90ff4646c1f7bad50e0b7790071da9c747b32193947R37-R39) [[4]](diffhunk://#diff-ca18eda25e1a814b3a2fa90ff4646c1f7bad50e0b7790071da9c747b32193947R361-R366)
* Updated the board and stable section components to support sandbox actions like bouncing, destroying, or stealing cards directly via the UI. [[1]](diffhunk://#diff-ca18eda25e1a814b3a2fa90ff4646c1f7bad50e0b7790071da9c747b32193947R60) [[2]](diffhunk://#diff-ca18eda25e1a814b3a2fa90ff4646c1f7bad50e0b7790071da9c747b32193947R241-R252) [[3]](diffhunk://#diff-a5373904afb63c3fb711dcdfe799c8e89a0b513b4bb0eeccd2c4bf7f975f9ce9R14) [[4]](diffhunk://#diff-a5373904afb63c3fb711dcdfe799c8e89a0b513b4bb0eeccd2c4bf7f975f9ce9R61-R62)

### Game Logic and State Management

* Ensured that dummy players in sandbox mode do not auto-end turns or auto-don't-Neigh, for more controlled testing.
* Improved deck reshuffling logic to only reshuffle when the draw pile is empty and the discard pile has cards.

### Refactoring and Exports

* Exported `Cards` and `KNOWN_EFFECTS` for easier access in other modules. [[1]](diffhunk://#diff-607bcb514f19f509a6e334d1bc3938e674f5835cca1af16081c8fa21ceb29bd0R3) [[2]](diffhunk://#diff-607bcb514f19f509a6e334d1bc3938e674f5835cca1af16081c8fa21ceb29bd0L14-R15) [[3]](diffhunk://#diff-6bf31261bcf57762fc90bd7876841ed537e45dec19da87c22deb9c912f8b4b31R3-R22)

---

These changes collectively enable a powerful sandbox/testing mode for developers, making it easier to simulate game states and test edge cases without normal gameplay restrictions.